### PR TITLE
Add cavaquinho as a static instrument in the tester

### DIFF
--- a/my-chords-tester/src/App.js
+++ b/my-chords-tester/src/App.js
@@ -4,6 +4,7 @@ import ChordBlock from '@tombatossals/react-chords/lib/Chord/ChordBlock'
 import guitarChords from '@tombatossals/chords-db/lib/guitar.json';
 import ukuleleChords from '@tombatossals/chords-db/lib/ukulele.json';
 import pianoChords from '@tombatossals/chords-db/lib/piano.json';
+import cavaquinhoChords from '@tombatossals/chords-db/lib/cavaquinho.json';
 import { addMidiToPosition } from '@tombatossals/react-chords/lib/Chord/midiUtils';
 import './App.css';
 
@@ -44,6 +45,19 @@ const instruments = {
             keys: [],
             tunings: {
                 standard: []
+            }
+        }
+    },
+    cavaquinho: {
+        name: 'Cavaquinho',
+        chords: cavaquinhoChords,
+        config: {
+            strings: 4,
+            fretsOnChord: 4,
+            name: 'Cavaquinho',
+            keys: [],
+            tunings: {
+                standard: ['D', 'G', 'B', 'D']
             }
         }
     }

--- a/my-chords-tester/src/App.test.js
+++ b/my-chords-tester/src/App.test.js
@@ -1,8 +1,30 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { BrowserRouter } from 'react-router-dom';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+describe('Cavaquinho Instrument Support', () => {
+  test('renders all instruments including cavaquinho', () => {
+    render(
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    );
+    
+    expect(screen.getByText('Guitar')).toBeInTheDocument();
+    expect(screen.getByText('Ukulele')).toBeInTheDocument();
+    expect(screen.getByText('Piano')).toBeInTheDocument();
+    expect(screen.getByText('Cavaquinho')).toBeInTheDocument();
+  });
+
+  test('cavaquinho is navigable', () => {
+    render(
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    );
+    
+    const cavaquinhoLink = screen.getByText('Cavaquinho');
+    expect(cavaquinhoLink).toBeInTheDocument();
+    expect(cavaquinhoLink.closest('a')).toHaveAttribute('href', '/cavaquinho');
+  });
 });


### PR DESCRIPTION
## Summary
This PR adds cavaquinho to the `react-chords` tester as a static instrument route so the library can render and browse the new cavaquinho chord dataset.

## Depends on
- `chords-db` PR adding the cavaquinho dataset and generated JSON
- this PR should be reviewed after that data PR, or with that branch available for local verification

## What changed
- added cavaquinho to the tester instrument navigation
- added cavaquinho route coverage in the app tests
- validated rendering against the cavaquinho chord JSON consumed by the tester

## Scope
This PR is intentionally minimal and keeps upstream scope narrow:
- no progression optimizer
- no fork-specific UI/UX redesign
- no routing changes beyond static instrument browsing
- no library API changes

## Validation
- tester route coverage updated for cavaquinho
- verified that cavaquinho pages render and that chord positions are available from the installed `@tombatossals/chords-db` data